### PR TITLE
Use highwater OFPort allocation (dovesnap will ask OVS to assign new …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     volumes:
       - /run/docker/plugins:/run/docker/plugins
       - /var/run/docker.sock:/var/run/docker.sock
+      - /usr/local/var/run/openvswitch:/usr/local/var/run/openvswitch
     network_mode: host
     stdin_open: true
     tty: true
@@ -21,6 +22,8 @@ services:
     image: openvswitch:2.13.0
     build:
       context: openvswitch
+    volumes:
+      - /usr/local/var/run/openvswitch:/usr/local/var/run/openvswitch
     privileged: true
     network_mode: host
     ports:

--- a/ovs/ovs_port.go
+++ b/ovs/ovs_port.go
@@ -3,7 +3,36 @@ package ovs
 import (
 	"errors"
 	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
 )
+
+func (ovsdber *ovsdber) lowestFreePortOnBridge(bridgeName string) (lowestFreePort uint, err error) {
+        output, err := OfCtl("dump-ports-desc", bridgeName)
+	if (err != nil) {
+		return 0, err
+	}
+	var ofportNumberDump = regexp.MustCompile(`^\s*(\d+)\(\S+\).+$`)
+	existingOfPorts := []int{}
+	for _, line := range strings.Split(string(output), "\n") {
+		match := ofportNumberDump.FindAllStringSubmatch(line, -1)
+		if len(match) > 0 {
+			ofport, _ := strconv.Atoi(match[0][1])
+			existingOfPorts = append(existingOfPorts, ofport)
+		}
+        }
+	sort.Ints(existingOfPorts)
+	intLowestFreePort := 1
+	for _, existingPort := range existingOfPorts {
+		if existingPort != intLowestFreePort {
+			break
+		}
+		intLowestFreePort++
+	}
+        return uint(intLowestFreePort), nil
+}
 
 func (ovsdber *ovsdber) createOvsInternalPort(prefix string, bridge string, tag uint) (port string, err error) {
 	// if you desire a longer hash add using generateRandomName(prefix, 5)
@@ -18,10 +47,14 @@ func (ovsdber *ovsdber) createOvsInternalPort(prefix string, bridge string, tag 
 }
 
 func (ovsdber *ovsdber) addInternalPort(bridgeName string, portName string, tag uint) error {
-	if (tag != 0) {
-		return VsCtl("add-port", bridgeName, portName, fmt.Sprintf("tag=%u", tag))
+	lowestFreePort, err := ovsdber.lowestFreePortOnBridge(bridgeName)
+	if (err != nil) {
+		return err
 	}
-	return VsCtl("add-port", bridgeName, portName)
+	if (tag != 0) {
+		return VsCtl("add-port", bridgeName, portName, fmt.Sprintf("tag=%u", tag), "--", "set", "Interface", portName, fmt.Sprintf("ofport_request=%d", lowestFreePort))
+	}
+	return VsCtl("add-port", bridgeName, portName, "--", "set", "Interface", portName, fmt.Sprintf("ofport_request=%d", lowestFreePort))
 }
 
 func (ovsdber *ovsdber) deletePort(bridgeName string, portName string) error {

--- a/ovs/ovsdb.go
+++ b/ovs/ovsdb.go
@@ -28,6 +28,7 @@ var (
 
 func VsCtl(args ...string) (error) {
         ovsvsctlPath := "/usr/local/bin/ovs-vsctl"
+	// TODO: we can use the Unix socket instead.
         dbStr := fmt.Sprintf("--db=tcp:%s:%d", localhost, ovsdbPort)
         all := append([]string{dbStr}, args...)
         output, err := exec.Command(ovsvsctlPath, all...).CombinedOutput()
@@ -37,6 +38,17 @@ func VsCtl(args ...string) (error) {
                 log.Debugf("OK: %s, %v", ovsvsctlPath, all)
         }
         return err
+}
+
+func OfCtl(args ...string) ([]byte, error) {
+        ovsofctlPath := "/usr/local/bin/ovs-ofctl"
+        output, err := exec.Command(ovsofctlPath, args...).CombinedOutput()
+        if err != nil {
+                log.Debugf("FAILED: %s, %v, %s", ovsofctlPath, args, output)
+        } else {
+                log.Debugf("OK: %s, %v", ovsofctlPath, args)
+        }
+        return output, err
 }
 
 type ovsdber struct {


### PR DESCRIPTION
…interfaces, the lowest possible free OFPort number).

This minimizes the number of preallocated FAUCET ports.

We ask OVS for allocated port numbers using ovs-ofctl. While it is possible to obtain this information via ovsdb,
it is much more complex - we have to ask the Bridge table for ports, the Ports table for Interfaces, and finally
the Interfaces table for OFPort numbers. Any of those transactions might fail or not be atomic.

ovs-ofctl uses a Unix domain socket for OpenFlow communication, so there is no extra OpenFlow TCP port necessary.
It would be good to remove the rest of dovesnap's legacy use of the ovsdb library and have it run ovs-vsctl over
a domain socket as well, which would reduce OVS' network attack surface further by not having to listen on the management port.